### PR TITLE
add misra_rules.txt

### DIFF
--- a/addons/config/misra_rules.txt
+++ b/addons/config/misra_rules.txt
@@ -1,0 +1,318 @@
+Appendix A Summary of guidelines
+
+Rule 1.1 Required
+Rule Required 1.1 The program shall contain no violations of the standard C syntax and constraints
+and shall not exceed the implementation's translation limits. 
+Rule 1.2 Advisory
+Rule Advisory 1.2 Language extensions should not be used.
+Rule 1.3 Required
+Rule Required 1.3 There shall be no occurrence of undefined or critical unspecified behaviour.
+Rule 1.4 Required
+Rule Required 1.4 Emergent language features shall not be used.
+Rule 2.1 Required
+Rule Required 2.1 A project shall not contain unreachable code.
+Rule 2.2 Required
+Rule Required 2.2 There shall be no dead code.
+Rule 2.3 Advisory
+Rule Advisory 2.3 A project should not contain unused type declarations.
+Rule 2.4 Advisory
+Rule Advisory 2.4 A project should not contain unused tag declarations.
+Rule 2.5 Advisory
+Rule Advisory 2.5 A project should not contain unused macro declarations.
+Rule 2.6 Advisory
+Rule Advisory 2.6 A function should not contain unused label declarations.
+Rule 2.7 Advisory
+Rule Advisory 2.7 There should be no unused parameters in functions.
+Rule 3.1 Required
+Rule Required 3.1 The character sequences /* and // shall not be used within a comment.
+Rule 3.2 Required
+Rule Required 3.2 Line-splicing shall not be used in // comments.
+Rule 4.1 Required
+Rule Required 4.1 Octal and hexadecimal escape sequences shall be terminated.
+Rule 4.2 Advisory
+Rule Advisory 4.2 Trigraphs should not be used.
+Rule 5.1 Required
+Rule Required 5.1 External identifiers shall be distinct.
+Rule 5.2 Required
+Rule Required 5.2 Identifiers declared in the same scope and name space shall be distinct.
+Rule 5.3 Required
+Rule Required 5.3 An identifier declared in an inner scope shall not hide an identifier declared in an outer scope.
+Rule 5.4 Required
+Rule Required 5.4 Macro identifiers shall be distinct.
+Rule 5.5 Required
+Rule Required 5.5 Identifiers shall be distinct from macro names.
+Rule 5.6 Required
+Rule Required 5.6 A typedef name shall be a unique identifier.
+Rule 5.7 Required
+Rule Required 5.7 A tag name shall be a unique identifier.
+Rule 5.8 Required
+Rule Required 5.8 Identifiers that define objects or functions with external linkage shall be unique.
+Rule 5.9 Advisory
+Rule Advisory 5.9 dentifiers that define objects or functions with internal linkage should be unique.
+Rule 6.1 Required
+Rule Required 6.1 Bit-fields shall only be declared with an appropriate type.
+Rule 6.2 Required
+Rule Required 6.2 Single-bit named bit fields shall not be of a signed type.
+Rule 7.1 Required
+Rule Required 7.1 Octal constants shall not be used.
+Rule 7.2 Required
+Rule Required 7.2 A "u" or "U" suffix shall be applied to all integer constants that are represented in an unsigned type.
+Rule 7.3 Required
+Rule Required 7.3 The lowercase character 'l' shall not be used in a literal suffix.
+Rule 7.4 Required
+Rule Required 7.4 A string literal shall not be assigned to an object unless the object's type is "pointer to const-qualified char".
+Rule 8.1 Required
+Rule Required 8.1 Types shall be explicitly specified.
+Rule 8.2 Required
+Rule Required 8.2 Function types shall be in prototype form with named parameters.
+Rule 8.3 Required
+Rule Required 8.3 All declarations of an object or function shall use the same names and type qualifiers.
+Rule 8.4 Required
+Rule Required 8.4 A compatible declaration shall be visible when an object or function with external linkage is defined.
+Rule 8.5 Required
+Rule Required 8.5 An external object or function shall be declared once in one and only one file.
+Rule 8.6 Required
+Rule Required 8.6 Rule Required 8.6 An identifier with external linkage shall have exactly one external definition.
+Rule 8.7 Advisory
+Rule Advisory 8.7 Rule Advisory 8.7 Functions and objects should not be defined with external linkage if they are referenced in only one.
+Rule 8.8 Required
+Rule Required 8.8 Rule Required 8.8 The static storage class specifier shall be used in all declarations of objects and functions that have internal linkage.
+Rule 8.9 Advisory
+Rule Advisory 8.9 Rule Advisory 8.9 An object should be defined at block scope if its identifier only appears in a single function.
+Rule 8.10 Required
+Rule Required 8.10 Rule Required 8.10 An inline function shall be declared with the static storage class.
+Rule 8.11 Required
+Rule Required 8.11 Rule Required 8.11 When an array with external linkage is declared its size should be explicitly specified.
+Rule 8.12 Required
+Rule Required 8.12 Rule Required 8.12 Within an enumerator list the value of an implicitly-specified enumeration constant shall be unique.
+Rule 8.13 Advisory
+Rule Advisory 8.13 Rule Advisory 8.13 A pointer should point to a const-qualified type whenever possible.
+Rule 8.14 Required
+Rule Required 8.14 Rule Required 8.14 The restrict type qualifier shall not be used.
+Rule 9.1 Mandatory
+Rule Mandatory 9.1 Rule Mandatory 9.1 The value of an object with automatic storage duration shall not be read before it has been set.
+Rule 9.2 Required
+Rule Required 9.2 Rule Required 9.2 The initializer for an aggregate or union shall be enclosed in bracese.
+Rule 9.3 Required
+Rule Required 9.3 Rule Required 9.3 Arrays shall not be partially initialized.
+Rule 9.4 Required
+Rule Required 9.4 Rule Required 9.4 An element of an object shall not be initialised more than once.
+Rule 9.5 Required
+Rule Required 9.5 Rule Required 9.5 Where designated initialisers are used to initialize an array object the size of the array shall be specified explicitly.
+Rule 10.1 Required
+Rule Required 10.1 Rule Required 10.1 Operands shall not be of an inappropriate essential type.
+Rule 10.2 Required
+Rule Required 10.2 Rule Required 10.2 Expressions of essentially character type shall not be used inappropriately in addition and.
+Rule 10.3 Required
+Rule Required 10.3 Rule Required 10.3 The value of an expression shall not be assigned to an object with a narrower essential type or of a different essential type category.
+Rule 10.4 Required
+Rule Required 10.4 Rule Required 10.4 Both operands of an operator in which the usual arithmetic conversions are performed shall have the same essential type category.
+Rule 10.5 Advisory
+Rule Advisory 10.5 Rule Advisory 10.5 The value of an expression should not be cast to an inappropriate essential type.
+Rule 10.6 Required
+Rule Required 10.6 Rule Required 10.6 The value of a composite expression shall not be assigned to an object with wider essential type.
+Rule 10.7 Required
+Rule Required 10.7 Rule Required 10.7 If a composite expression is used as one operand of an operator in which the usual arithmetic conversions are performed then the other operand.
+Rule 10.8 Required
+Rule Required 10.8 Rule Required 10.8 The value of a composite expression shall not be cast to a different essential type category or a wider essential type.
+Rule 11.1 Required
+Rule Required 11.1 Rule Required 11.1 Conversions shall not be performed between a pointer to a function and any other type.
+Rule 11.2 Required
+Rule Required 11.2 Rule 11.2 Required Conversions shall not be performed between a pointer to incomplete and any other type.
+Rule 11.3 Required
+Rule Required 11.3 A cast shall not be performed between a pointer to object type and a pointer to a different object type.
+Rule 11.4 Advisory
+Rule Advisory 11.4 A conversion should not be performed between a pointer to.
+Rule 11.5 Advisory
+Rule Advisory 11.5 A conversion should not be performed from pointer to void into pointer to object.
+Rule 11.6 Required
+Rule Required 11.6 A cast shall not be performed between pointer to void and an.
+Rule 11.7 Required
+Rule Required 11.7 A cast shall not be performed between pointer to object and a non-integer arithmetic type.
+Rule 11.8 Required
+Rule Required 11.8 A cast shall not remove any const or volatile qualification from the type.
+Rule 11.9 Required
+Rule Required 11.9 The macro NULL shall be the only permitted form of integer null pointer constant.
+Rule 12.1 Advisory
+Rule Advisory 12.1 The precedence of operators within expressions should be made explicit.(表达式中操作符的优先级应该明确。)
+Rule 12.2 Required
+Rule Required 12.2 The right hand operand of a shift operator shall lie in the range zero to one less than the width in bits of the.
+Rule 12.3 Advisory
+Rule Advisory 12.3 The comma operator should not be used.(不应该使用逗号操作符。)
+Rule 12.4 Advisory
+Rule Advisory 12.4 Evaluation of constant expressions should not lead to unsigned integer.
+Rule 13.1 Required
+Rule Required 13.1 Initialiser lists shall not contain persistent side effects.
+Rule 13.2 Required
+Rule Required 13.2 The value of an expression and its persistent side effects shall be the same under all permitted evaluation orders.
+Rule 13.3 Advisory
+Rule Advisory 13.3 A full expression containing an increment (++) or decrement (--) operator should have no other potential side effects other than that caused by the increment or decrement operator.(包含++或--的语句不应该有其他潜在的副作用。)
+Rule 13.4 Advisory
+Rule Advisory 13.4 The result of an assignment operator should not be used.(不要使用赋值操作的结果，如if(a=2),也不要连续赋值，如a=b=c=2。)
+Rule 13.5 Required
+Rule Required 13.5 The right hand operand of a logical && or || operator shall not contain persistent side effects.
+Rule 13.6 Mandatory
+Rule Mandatory 13.6 The operand of the sizeof operator shall not contain any expression which has potential side effects.
+Rule 14.1 Required
+Rule Required 14.1 A loop counter shall not have essentially floating type.
+Rule 14.2 Required
+Rule Required 14.2 A for loop shall be well-formed.
+Rule 14.3 Required
+Rule Required 14.3 Controlling expressions shall not be invariant.
+Rule 14.4 Required
+Rule Required 14.4 The controlling expression of an if statement and the controlling expression of an iteration-statement shall have essentially Boolean type.
+Rule 15.1 Advisory
+Rule Advisory 15.1 The goto statement should not be used.
+Rule 15.2 Required
+Rule Required 15.2 The goto statement shall jump to a label declared later in the same function.
+Rule 15.3 Required
+Rule Required 15.3 Any label referenced by a goto statement shall be declared in the same block
+or in any block enclosing the goto statement.
+Rule 15.4 Advisory
+Rule Advisory 15.4 There should be no more than one break or goto statement used to terminate any iteration statement.
+Rule 15.5 Advisory
+Rule Advisory 15.5 A function should have a single point of exit at the end.(函数应该只有一个return的地方。)
+Rule 15.6 Required
+Rule Required 15.6 The body of an iteration-statement or a selection-statement shall be a compound statement.
+Rule 15.7 Required
+Rule Required 15.7 All if else if constructs shall be terminated with an else statement.
+Rule 16.1 Required
+Rule Required 16.1 All switch statements shall be well-formed.
+Rule 16.2 Required
+Rule Required 16.2 A switch label shall only be used when the most closely-enclosing compound statement is the body of a switch statement.
+Rule 16.3 Required
+Rule Required 16.3 An unconditional break statement shall terminate every switch-clause.
+Rule 16.4 Required
+Rule Required 16.4 Every switch statement shall have a default label.
+Rule 16.5 Required
+Rule Required 16.5 A default label shall appear as either the first or the last switch label of a switch statement.
+Rule 16.6 Required
+Rule Required 16.6 Every switch statement shall have at least two switch-clauses.
+Rule 16.7 Required
+Rule Required 16.7 A switch-expression shall not have essentially Boolean type.
+Rule 17.1 Required
+Rule Required 17.1 The features of <stdarg.h> shall not be used.
+Rule 17.2 Required
+Rule Required 17.2 Functions shall not call themselves, either directly or indirectly.
+Rule 17.3 Mandatory
+Rule Mandatory 17.3 A function shall not be declared implicitly.
+Rule 17.4 Mandatory
+Rule Mandatory 17.4 All exit paths from a function with non-void return type shall have an explicit return statement with an expression.
+Rule 17.5 Advisory
+Rule Advisory 17.5 The function argument corresponding to a parameter declared to have an array type shall have an appropriate number of elements.
+Rule 17.6 Mandatory
+Rule Mandatory 17.6 The declaration of an array parameter shall not contain the static keyword between the [ ].
+Rule 17.7 Required
+Rule Required 17.7 The value returned by a function having non-void return type shall be used.
+Rule 17.8 Advisory
+Rule Advisory 17.8 A function parameter should not be modified.
+Rule 18.1 Required
+Rule Required 18.1 A pointer resulting from arithmetic on a pointer operand shall address an element of the same array as that pointer operand.
+Rule 18.2 Required
+Rule Required 18.2 Subtraction between pointers shall only be applied to pointers that address elements of the same array.
+Rule 18.3 Required
+Rule Required 18.3 The relational operators '>'  '>='  '<' and '<=' shall not be applied to objects of pointer type except where they point into the same object.
+Rule 18.4 Advisory
+Rule Advisory 18.4 The '+'  '-' '+=' and '-=' operators should not be applied to an expression of.
+Rule 18.5 Advisory
+Rule Advisory 18.5 Declarations should contain no more than two levels of pointer nesting.
+Rule 18.6 Required
+Rule Required 18.6 The address of an object with automatic storage shall not be copied to another object that persists after the first object has ceased to exist.
+Rule 18.7 Required
+Rule Required 18.7 Flexible array members shall not be declared.
+Rule 18.8 Required
+Rule Required 18.8 Variable-length array types shall not be used.
+Rule 19.1 Mandatory
+Rule Mandatory 19.1 An object shall not be assigned or copied to an overlapping object.
+Rule 19.2 Advisory
+Rule Advisory 19.2 The union keyword should not be used.
+Rule 20.1 Advisory
+Rule Advisory 20.1 #include directives should only be preceded by preprocessor directives or comments.
+Rule 20.2 Required
+Rule Required 20.2 The ', " or \ characters and the /* or // character sequences shall not occur in a header file name.
+Rule 20.3 Required
+Rule Required 20.3 The #include directive shall be followed by either a <filename> or "filename" sequence.
+Rule 20.4 Required
+Rule Required 20.4 A macro shall not be defined with the same name as a keyword.
+Rule 20.5 Advisory
+Rule Advisory 20.5 #undef should not be used.
+Rule 20.6 Required
+Rule Required 20.6 Tokens that look like a preprocessing directive shall not occur within a macro argument.
+Rule 20.7 Required
+Rule Required 20.7 Expressions resulting from the expansion of macro parameters shall.
+Rule 20.8 Required
+Rule Required 20.8 The controlling expression of a #if or #elif preprocessing directive shall evaluate to 0 or 1.
+Rule 20.9 Required
+Rule Required 20.9 All identifiers used in the controlling expression of #if or #elif preprocessing directives shall be #define'd before evaluation.
+Rule 20.10 Advisory
+Rule Advisory 20.10 The # and ## preprocessor operators should not be used.
+Rule 20.11 Required
+Rule Required 20.11 A macro parameter immediately following a # operator shall not immediately be followed by a ## operator.
+Rule 20.12 Required
+Rule Required 20.12 A macro parameter used as an operand to the # or ## operators, which is itself subject to further macro replacement, shall only be used as an operand to these operators.
+Rule 20.13 Required
+Rule Required 20.13 A line whose first token is # shall be a valid preprocessing directive.
+Rule 20.14 Required
+Rule Required 20.14 All #else, #elif and #endif preprocessor directives shall reside in the same file as the #if, #ifdef or.
+Rule 21.1 Required
+Rule Requirede 21.1 #define and #undef shall not be used on a reserved identifier or reserved macro name.
+Rule 21.2 Required
+Rule Required 21.2 A reserved identifier or macro name shall not be declared.
+Rule 21.3 Required
+Rule Required 21.3 The memory allocation and deallocation functions of <stdlib.h> shall not be used.
+Rule 21.4 Required
+Rule Required 21.4 The standard header file <setjmp.h> shall not be used.
+Rule 21.5 Required
+Rule Required 21.5 The standard header file <signal.h> shall not be used.
+Rule 21.6 Required
+Rule Required 21.6 The Standard Library input/output routines shall not be used.
+Rule 21.7 Required
+Rule Required 21.7 The atof, atoi, atol and atoll functions of <stdlib.h> shall not be used.
+Rule 21.8 Required
+Rule Required 21.8 The library functions abort, exit, getenv and system of <stdlib.h>.
+Rule 21.9 Required
+Rule Required 21.9 The library functions bsearch and qsort of <stdlib.h> shall not be used.
+Rule 21.10 Required
+Rule Required 21.10 The Standard Library time and date routines shall not be used.
+Rule 21.11 Required
+Rule Required 21.11 The standard header file <tgmath.h> shall not be used.
+Rule 21.12 Advisory
+Rule Advisory 21.12 The exception handling features of <fenv.h> should not be used.
+Rule 21.13 Mandatory
+Rule Mandatory 21.13 Any value passed to a function in <ctype.h> shall be representable as an unsigned char or be the value EO
+Rule 21.14 Required
+Rule Required 21.14 The Standard Library function memcmp shall not be used to compare null terminated strings
+Rule 21.15 Required
+Rule Required 21.15 The pointer arguments to the Standard Library functions memcpy, memmove and memcmp shall be pointers to qualified or unqualified versions of compatible types
+Rule 21.16 Required
+Rule Required 21.16 The pointer arguments to the Standard Library function memcmp shall point to either a pointer type, an essentially signed type, an essentially unsigned type, an essentially Boolean type or an essentially enum type
+Rule 21.17 Mandatory
+Rule Mandatory 21.17 Use of the string handling functions from <string.h> shall not result in accesses beyond the bounds of the objects referenced by their pointer parameters
+Rule 21.18 Mandatory
+Rule Mandatory 21.18 The size_t argument passed to any function in <string.h> shall have an appropriate value
+Rule 21.19 Mandatory
+Rule Mandatory 21.19 The pointers returned by the Standard Library functions localeconv, getenv, setlocale or, strerror shall only be used as if they have pointer to const-qualified type
+Rule 21.20 Mandatory
+Rule Mandatory 21.20 The pointer returned by the Standard Library functions asctime, ctime, gmtime, localtime, localeconv, getenv, setlocale or strerror shall not be used following a subsequent call to the same function
+Rule 21.21 Required
+Rule Required 21.21 The Standard Library function system of shall not be used.
+Rule 22.1 Required
+Rule Required 22.1 All resources obtained dynamically by means of Standard Library functions shall be explicitly released.
+Rule 22.2 Mandatory
+Rule Mandatory 22.2 A block of memory shall only be freed if it was allocated by means of a Standard Library function.
+Rule 22.3 Required
+Rule Required 22.3 The same file shall not be open for read and write access at the same time on different streams.
+Rule 22.4 Mandatory
+Rule Mandatory 22.4 There shall be no attempt to write to a stream which has been opened as read-only
+Rule 22.5 Mandatory
+Rule Mandatory 22.5 A pointer to a FILE object shall not be dereferenced.
+Rule 22.6 Mandatory
+Rule Mandatory 22.6 The value of a pointer to a FILE shall not be used after the associated stream has been closed.
+Rule 22.7 Required
+Rule Required 22.7 The macro EOF shall only be compared with the unmodified return value from any Standard Library function capable of returning EOF
+Rule 22.8 Required
+Rule Required The value of errno shall be set to zero prior to a call to an errno-setting-function
+Rule 22.9 Required
+Rule Required The value of errno shall be tested against zero after calling an errno-setting-function
+Rule 22.10 Required
+Rule Required The value of errno shall only be tested when the last function to be called was an errno-setting-function


### PR DESCRIPTION
misra.py脚本需要指定规则对应的说明 --rule-texts 否则只会返回rule_id, 这里根据相关信息手动构造对应的规则说明文件